### PR TITLE
BSS2-2306 receive and process hyphenated pytest markers

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,6 +2,7 @@
 
 BASE_URL=${1:-${BASE_URL}}
 MARKERS_TO_USE=${2:=${MARKERS_TO_USE}}
+MARKERS_TO_USE="${MARKERS_TO_USE//-/ }"
 export COGNITO_USER_PASSWORD=${3:=${COGNITO_USER_PASSWORD}}
 
 pytest --tracing retain-on-failure --base-url $1 -m "$2"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,4 +5,4 @@ MARKERS_TO_USE=${2:=${MARKERS_TO_USE}}
 MARKERS_TO_USE="${MARKERS_TO_USE//-/ }"
 export COGNITO_USER_PASSWORD=${3:=${COGNITO_USER_PASSWORD}}
 
-pytest --tracing retain-on-failure --base-url $1 -m "$2"
+pytest --tracing retain-on-failure -p no:warnings --base-url $BASE_URL -m "$MARKERS_TO_USE"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
+BASE_URL=$1
 MARKERS_TO_USE="${2//-/ }" # replace hyphens with spaces
 export COGNITO_USER_PASSWORD=$3
 
-pytest --tracing retain-on-failure --base-url $1 -m "$MARKERS_TO_USE"
+pytest --tracing retain-on-failure --base-url $BASE_URL -m "$MARKERS_TO_USE"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 BASE_URL=${1:-${BASE_URL}}
 MARKERS_TO_USE=${2:=${MARKERS_TO_USE}}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,4 +5,4 @@ MARKERS_TO_USE=${2:=${MARKERS_TO_USE}}
 MARKERS_TO_USE="${MARKERS_TO_USE//-/ }"
 export COGNITO_USER_PASSWORD=${3:=${COGNITO_USER_PASSWORD}}
 
-pytest --tracing retain-on-failure -p no:warnings --base-url $BASE_URL -m "$MARKERS_TO_USE"
+pytest --tracing retain-on-failure --base-url $BASE_URL -m "$MARKERS_TO_USE"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MARKERS_TO_USE="${2//-/ }"
+MARKERS_TO_USE="${2//-/ }" # replace hyphens with spaces
 export COGNITO_USER_PASSWORD=$3
 
 pytest --tracing retain-on-failure --base-url $1 -m "$MARKERS_TO_USE"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-BASE_URL=${1:-${BASE_URL}}
-MARKERS_TO_USE=${2:=${MARKERS_TO_USE}}
-MARKERS_TO_USE="${MARKERS_TO_USE//-/ }"
-export COGNITO_USER_PASSWORD=${3:=${COGNITO_USER_PASSWORD}}
+MARKERS_TO_USE="${2//-/ }"
+export COGNITO_USER_PASSWORD=$3
 
-pytest --tracing retain-on-failure --base-url $BASE_URL -m "$MARKERS_TO_USE"
+pytest --tracing retain-on-failure --base-url $1 -m "$MARKERS_TO_USE"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The passed in value for MARKERS_TO_USE now has hyphens instead of spaces. The hyphens need to be replaced with spaces in order to make the markers readable by pytest. 

## Context

We pass the markers value from the Kubernetes script that runs the tests on the docker image of `bs-select-playwright` as part of the `bs-select-app` build pipeline. It makes sense to use a value with hyphens in `bs-select-app` and remove them in `bs-select-playwright`.

Note: the shell script now uses bash instead of dash as the regex that subs the hyphens out for spaces doesn't work on dash.

A third change is to prefer the env vars to the passed args in the pytest command.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](https://github.com/NHSDigital/bs-select-playwright/blob/main/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes (where appropriate)
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
