### PR TITLE
BSS2-2400 address second set of SonarCloud code quality issues

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,8 @@ import logging
 import os
 from pathlib import Path
 import typing
+from collections.abc import MutableMapping
+from typing import Any
 
 import pytest
 from dotenv import load_dotenv
@@ -70,7 +72,7 @@ def ni_ri_sp_batch_page(page: Page) -> NiRiSpBatchPage:
     return NiRiSpBatchPage(page)
 
 # This variable is used for JSON reporting only
-ENVIRONMENT_DATA = {}
+ENVIRONMENT_DATA = None
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -129,7 +131,7 @@ def pytest_json_runtest_metadata(item: object) -> dict:
 
 
 @pytest.hookimpl(optionalhook=True)
-def pytest_json_modifyreport(json_report: object) -> None:
+def pytest_json_modifyreport(json_report: MutableMapping[str, Any]) -> None:
     # Add env data to json report if present
     if ENVIRONMENT_DATA != None:
         json_report["environment_data"] = ENVIRONMENT_DATA

--- a/tests/ui/cohort_manager/test_cohort_manager_lambda_integration.py
+++ b/tests/ui/cohort_manager/test_cohort_manager_lambda_integration.py
@@ -924,9 +924,7 @@ def get_latest_records_by_nhs_number(db_conn, nhs_number, limit) -> DataFrame | 
 def wait_for_assertion(assert_func, timeout=90, interval=3):
     end_time = time.time() + timeout
 
-    counter = 0
     while time.time() < end_time:
-        counter += 1
         if assert_func():
             return
         time.sleep(interval)

--- a/tests/ui/cohort_manager/test_cohort_manager_lambda_integration.py
+++ b/tests/ui/cohort_manager/test_cohort_manager_lambda_integration.py
@@ -788,7 +788,7 @@ def test_death_date_and_reason_for_removal_populated_using_dummy_gp_practice_cod
     )
     assert (
         fetch_subject_column_value(db_util, nhs_number_16, "gp_practice_id") == 100032
-    )  # todo add UI assertions
+    )
     assert (
         fetch_subject_column_value(db_util, nhs_number_17, "removal_reason")
         == "REMOVAL"

--- a/tests/ui/rlp_screening_cohort_list/test_rlp_screening_cohort_list_by_outcode.py
+++ b/tests/ui/rlp_screening_cohort_list/test_rlp_screening_cohort_list_by_outcode.py
@@ -478,7 +478,7 @@ def test_outcode_search_feature_using_cohort_type(
     rlp_cohort_list_page.select_cohort_type_dropdown(search_term)
     filtered_values = page.locator("//tbody/tr/td[6]").all_text_contents()
     # Assert that each value contains "cohort"
-    if search_term is "All":
+    if search_term == "All":
         ui_row_count_after = rlp_cohort_list_page.extract_cohort_paging_info()
         assert ui_row_count_before == ui_row_count_after
     else:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR catches 4 that were missed in the [original PR](https://github.com/NHSDigital/bs-select-playwright/pull/21).

Eliminate all the issues identified by SonarCloud in order to align with Python Enhancement Proposals (PEPs)

[Jira issue](https://nhsd-jira.digital.nhs.uk/browse/BSS2-2400)

## Context

Start as we mean to go on with a clean codebase with no warnings :)

Note: I recommended to review this PR commit by commit as I have bunched similar changes together.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](https://github.com/NHSDigital/bs-select-playwright/blob/main/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes (where appropriate)
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
